### PR TITLE
added mini-export for the full version

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -38,7 +38,7 @@ module.exports = (grunt) ->
           'src/hammer-export.js' # simple export
 
           'src/plugin.js'
-          'src/export.js'
+          'src/mini-export.js'
           'src/jquery.hammer.suffix']
         dest: 'jquery.hammer-full.js'
 

--- a/src/mini-export.js
+++ b/src/mini-export.js
@@ -1,6 +1,9 @@
 // AMD
 if(typeof define == 'function' && define.amd) {
-  define(setupPlugin);
+  define(function () {
+
+  	return setupPlugin(window.Hammer, window.jQuery || window.Zepto);
+  });
 }
 
 else {

--- a/src/mini-export.js
+++ b/src/mini-export.js
@@ -1,8 +1,8 @@
 // AMD
 if(typeof define == 'function' && define.amd) {
-  define(function () {
+  define(['jquery'], function ($) {
 
-  	return setupPlugin(window.Hammer, window.jQuery || window.Zepto);
+  	return setupPlugin(window.Hammer, $);
   });
 }
 

--- a/src/mini-export.js
+++ b/src/mini-export.js
@@ -1,0 +1,8 @@
+// AMD
+if(typeof define == 'function' && define.amd) {
+  define(setupPlugin);
+}
+
+else {
+  setupPlugin(window.Hammer, window.jQuery || window.Zepto);
+}


### PR DESCRIPTION
@jtangelder  I looked at the changes you made in https://github.com/EightMedia/jquery.hammer.js/commit/5991e603700caa01ecae8ea432ca089376ffbf69

However in the full version the dependency of naming the Hammer library 'hammerjs' for amd users still remains, this may cause issues for some devs. I propose in the full version to always use the Hammer and jQuery instances attached to the window object.

Please let me know what you think. 

Love the library by the way!
