### PR TITLE
Allow trigger of target element

### DIFF
--- a/jquery.hammer.js
+++ b/jquery.hammer.js
@@ -24,7 +24,11 @@
     Hammer.Manager.prototype.emit = (function(originalEmit) {
         return function(type, data) {
             originalEmit.call(this, type, data);
-            $(this.element).trigger({
+            var el = $(this.element);
+            if(el.has(data.target).length) {
+               el = $(data.target);
+            }
+            el.trigger({
                 type: type,
                 gesture: data
             });

--- a/jquery.hammer.js
+++ b/jquery.hammer.js
@@ -26,7 +26,7 @@
             originalEmit.call(this, type, data);
             var el = $(this.element);
             if(el.has(data.target).length) {
-               el = $(data.target);
+               el = el.find(data.target);
             }
             el.trigger({
                 type: type,


### PR DESCRIPTION
My team decided that we would like to update one of our applications to jquery-hammer v2 but our app needs to be able to delegate all events for a component's children before child elements are added to the DOM.  This worked fine in v1 of jquery-hammerjs as it used to trigger events using event.target if targets existed.  I've added this functionality back but I'm not sure what the reasoning for changing this was?
