### PR TITLE
Bump minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-hammerjs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "jquery.hammer.js",
   "main": "jquery.hammer.js",
   "scripts": {
@@ -15,8 +15,10 @@
     "jquery"
   ],
   "dependencies": {
-    "hammerjs": "2.0.x",
-    "jquery": "2.1.x"
+    "hammerjs": "2.0.x"
+  },
+  "peerDependencies": {
+    "jquery": "*"
   },
   "author": "J. Tangelder",
   "license": "MIT",


### PR DESCRIPTION
Reflect API variance from changes to exports.  Any version of jquery since npm was created should be usable, and likely better as a peer dependency.
