### PR TITLE
Prevent event from bubbling up for children elements with individual hammer instances

### DIFF
--- a/jquery.hammer.js
+++ b/jquery.hammer.js
@@ -24,7 +24,7 @@
     Hammer.Manager.prototype.emit = (function(originalEmit) {
         return function(type, data) {
             originalEmit.call(this, type, data);
-            $(this.element).trigger({
+            $(this.element).triggerHandler({
                 type: type,
                 gesture: data
             });


### PR DESCRIPTION
This handles the scenario when there's a parent hammer instance delegating events, and a chid with another hammer instance triggers a parent's delegated event with the child's data. For example:

```
<div class="container">
       <div class="inner-container">
              <img />
      </div>
  </div>
```

**Setup**:
- container div, initiates a hammer instance with domEvents: true.
- container div delegates an event ( panstart ) to inner-container
- image element initiates another hammer instance with different recognizers/options and domEvents false and has a panstart handler as well.

**Steps:**
1. When the target is the image element, first the image handler will fire because of the event delegation in the parent, that is expected and can be prevented by checking for the originalEvent property in the handler, or creating a hammer instance without the plugin.
2. Then, the delegated event for inner-container will fire, and the expected handler for the image with its individual data options will fire next.
3. Because of trigger, when the image is this.element will also fire the delegated event on inner-container with the image data options. triggerHandler will only affect the first matched element and will not bubble up the DOM hierarchy.

This is useful for plugin-like functionality when a file wants to bind hammer events to elements, but in a specific context the element might already have a parent with a delegating hammer instance.
