### PR TITLE
Switch to triggerHandler

### DIFF
--- a/jquery.hammer.js
+++ b/jquery.hammer.js
@@ -24,7 +24,7 @@
     Hammer.Manager.prototype.emit = (function(originalEmit) {
         return function(type, data) {
             originalEmit.call(this, type, data);
-            $(this.element).trigger({
+            $(this.element).triggerHandler({
                 type: type,
                 gesture: data
             });


### PR DESCRIPTION
Prevents events from bubbling up for children elements with individual hammer instances
